### PR TITLE
Exclude webmvc when using Webflux, mvc on classpath creates issues

### DIFF
--- a/keycloak-demos/spring-boot-2-webflux-frontend/pom.xml
+++ b/keycloak-demos/spring-boot-2-webflux-frontend/pom.xml
@@ -26,6 +26,12 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-webmvc</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
@AutoConfigureWebTestClient funktioniert mit Junit5 sonnst nicht.